### PR TITLE
Support ambiguous nucleotide codes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,19 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.0.2</version>
+                <configuration>
+                    <finalName>dunes</finalName>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
-                    <finalName>dunes</finalName>
                     <archive>
                         <manifest>
                             <mainClass>Main</mainClass>
@@ -49,8 +57,6 @@
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
-                    <appendAssemblyId>false</appendAssemblyId>
-                    <outputDirectory>../dunes</outputDirectory>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -35,16 +35,14 @@
                 <!-- Build an executable JAR -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
                 <configuration>
-                    <finalName>dunes</finalName>
                     <archive>
                         <manifest>
-                            <addClasspath>true</addClasspath>
                             <mainClass>Main</mainClass>
                         </manifest>
                     </archive>
                 </configuration>
+                <version>3.0.2</version>
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
@@ -54,6 +52,7 @@
                             <mainClass>Main</mainClass>
                         </manifest>
                     </archive>
+                    <finalName>dunes</finalName>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -7,7 +7,10 @@ import org.biojava.nbio.core.sequence.AccessionID;
 import org.biojava.nbio.core.sequence.io.FastaWriterHelper;
 import picocli.CommandLine;
 import org.biojava.nbio.core.sequence.DNASequence;
-import org.biojava.nbio.core.sequence.io.FastaReaderHelper;
+import org.biojava.nbio.core.sequence.io.DNASequenceCreator;
+import org.biojava.nbio.core.sequence.compound.AmbiguityDNACompoundSet; 
+import org.biojava.nbio.core.sequence.io.FastaReader;
+import org.biojava.nbio.core.sequence.io.GenericFastaHeaderParser;
 
 @CommandLine.Command(name = "dunes", mixinStandardHelpOptions = true, version = "0.0")
 public class Main implements Runnable{
@@ -37,7 +40,11 @@ public class Main implements Runnable{
     public void run() {
         try {
             nuc_mut_prob = Math.pow(1+rate,years) - 1;
-            LinkedHashMap<String, DNASequence> seqs = FastaReaderHelper.readFastaDNASequence(inputFile);
+            AmbiguityDNACompoundSet ambiguityDNACompoundSet = AmbiguityDNACompoundSet.getDNACompoundSet();
+            DNASequenceCreator ambigDNASequenceCreator = new DNASequenceCreator(ambiguityDNACompoundSet);
+            GenericFastaHeaderParser fastaHeaderParser = new GenericFastaHeaderParser();
+            FastaReader fastaReader = new FastaReader(inputFile, fastaHeaderParser, ambigDNASequenceCreator);
+            LinkedHashMap<String, DNASequence> seqs = fastaReader.process(); 
             Set<String> seq_names = seqs.keySet();
             LinkedHashSet<DNASequence> out_seqs = new LinkedHashSet<>();
             if(outputFile == null) {
@@ -81,6 +88,6 @@ public class Main implements Runnable{
             if (nuc == mut_nuc) nuc = nucs.get(3);
             mut_seq.append(nuc);
         }
-        return new DNASequence(mut_seq.toString());
+        return new DNASequence(mut_seq.toString(), AmbiguityDNACompoundSet.getDNACompoundSet());
     }
 }


### PR DESCRIPTION
This update does three things:

1) It updates the code to use FastaReader instead of FastaReaderHelper so that we can specify the AmbiguousDNACompoundSet
2) It updates the DNASequence created in the mut_seq step to specify the AmbiguousDNACompoundSet
3) Updates the pom.xml file to create an executable jar with the required dependencies (I know that it was already set up that way, I'm not sure what the problem was, but it should be working correctly now)