### PR TITLE
add selectable mutation distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ java -jar dunes.jar
 ```bash
 java -jar dunes.jar -h
 
-Usage: dunes [-hV] -i=FILE [-m=m] [-n=n] [-o=<outputFolder>] [-y=y]
+Usage: dunes [-hV] -i=FILE [-m=m] [-n=n] [-o=<outputFolder>] [-y=y] [-d=d]
   -h, --help               Show this help message and exit.
+  -d, --distribution <distribution>       mutation model to use: 'simple' (equal-probability) or 'hiv' (HIV-like) (default: 'simple')
   -i, --inFile=FILE        input fasta file with viral sequences to be mutated
   -m, --mutation-rate=m    mutation rate in substitutions per nucleotide per year
                              (s/n/y) (default: 4.1e-3)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A command line tool for introducing random mutations into DNA sequences.
 ## Download or Compilation
 
 - Download:
-[dunes.jar](https://github.com/Sergey-Knyazev/dunes/releases/download/0.1.1/dunes.jar)
+[dunes.jar](https://github.com/dacowan404/dunes/releases/tag/0.1.2/dunes-jar-with-dependencies.jar)
 
 - Compilation:
 ```bash

--- a/README.md
+++ b/README.md
@@ -35,4 +35,27 @@ Usage: dunes [-hV] -i=FILE [-m=m] [-n=n] [-o=<outputFolder>] [-y=y] [-d=d]
   -V, --version            Print version information and exit.
   -y, --years=y            years of evolution (default: 1)
 ```
+
+## Distribution Matrices
+
+Rows indicate the original base and columns indicate the mutated base. These probabilities are applied only after a mutation event has been selected for a nucleotide.
+
+### `simple`
+
+| From \ To | A | C | G | T |
+| --- | ---: | ---: | ---: | ---: |
+| A | 0.0 | 0.33 | 0.33 | 0.33 |
+| C | 0.33 | 0.0 | 0.33 | 0.33 |
+| G | 0.33 | 0.33 | 0.0 | 0.33 |
+| T | 0.33 | 0.33 | 0.33 | 0.0 |
+
+### `hiv`
+
+| From \ To | A | C | G | T |
+| --- | ---: | ---: | ---: | ---: |
+| A | 0.0 | 0.15 | 0.70 | 0.15 |
+| C | 0.15 | 0.0 | 0.15 | 0.70 |
+| G | 0.80 | 0.10 | 0.0 | 0.10 |
+| T | 0.15 | 0.70 | 0.15 | 0.0 |
+
 ![DUNES](https://github.com/Sergey-Knyazev/dunes/blob/master/DUNES%20icon_2.svg)

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -32,14 +32,68 @@ public class Main implements Runnable{
     @CommandLine.Option(names={"-n", "--mutants-number"},
             description="number of mutants for a strain (default: 1)",
             paramLabel = "n")
-    private double n = 1;
+    private int n = 1;
+    @CommandLine.Option(names={"-d", "--distribution"},
+            description="mutation model to use: 'simple' (equal-probability) or 'hiv' (HIV-like) (default: 'simple')",
+            paramLabel = "distribution")
+    private String distribution = "simple";
+
     private double nuc_mut_prob;
-    private static List<Character> nucs = new ArrayList<Character>() {{add('A'); add('C'); add('T'); add('G');}};
     private static Random rand = new Random();
+
+    private static final List<Character> CANONICAL = Arrays.asList('A', 'C', 'G', 'T');
+
+    // Matrix to use for mutation probabilities
+    private double[][] selectedMatrix;
+
+    private static final Map<Character, char[]> IUPAC_MAP = new HashMap<Character, char[]>() {{
+        put('A', new char[]{'A'});
+        put('C', new char[]{'C'});
+        put('G', new char[]{'G'});
+        put('T', new char[]{'T'});
+        put('U', new char[]{'T'});
+        put('R', new char[]{'A','G'});
+        put('Y', new char[]{'C','T'});
+        put('S', new char[]{'G','C'});
+        put('W', new char[]{'A','T'});
+        put('K', new char[]{'G','T'});
+        put('M', new char[]{'A','C'});
+        put('B', new char[]{'C','G','T'});
+        put('D', new char[]{'A','G','T'});
+        put('H', new char[]{'A','C','T'});
+        put('V', new char[]{'A','C','G'});
+        put('N', new char[]{'A','C','G','T'});
+        put('-', new char[]{'-'});
+    }};
+
+    // Equal-probability simple model
+    private static final double[][] SIMPLE_MATRIX = {
+        {0.0, 1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0}, // A -> C,G,T
+        {1.0 / 3.0, 0.0, 1.0 / 3.0, 1.0 / 3.0}, // C -> A,G,T
+        {1.0 / 3.0, 1.0 / 3.0, 0.0, 1.0 / 3.0}, // G -> A,C,T
+        {1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0, 0.0} // T -> A,C,G
+    };
+
+    // First-pass HIV-like matrix
+    private static final double[][] HIV_MATRIX = {
+        {0.0, 0.15, 0.70, 0.15}, // A -> C,G,T
+        {0.15, 0.0, 0.15, 0.70}, // C -> A,G,T
+        {0.80, 0.10, 0.0, 0.10}, // G -> A,C,T
+        {0.15, 0.70, 0.15, 0.0} // T -> A,C,G
+    };
+
 
     public void run() {
         try {
             nuc_mut_prob = Math.pow(1+rate,years) - 1;
+
+            // Select mutation matrix based on distribution selected
+            if (distribution.equalsIgnoreCase("hiv")) {
+                selectedMatrix = HIV_MATRIX;
+            } else {
+                selectedMatrix = SIMPLE_MATRIX;
+            }
+
             AmbiguityDNACompoundSet ambiguityDNACompoundSet = AmbiguityDNACompoundSet.getDNACompoundSet();
             DNASequenceCreator ambigDNASequenceCreator = new DNASequenceCreator(ambiguityDNACompoundSet);
             GenericFastaHeaderParser fastaHeaderParser = new GenericFastaHeaderParser();
@@ -76,17 +130,64 @@ public class Main implements Runnable{
         return out_seqs;
     }
 
+    private static char resolveAmbiguousBase(char nuc) {
+        nuc = Character.toUpperCase(nuc);
+        char[] choices = IUPAC_MAP.get(nuc);
+
+        if (choices == null) {
+            throw new IllegalArgumentException("Unsupported nucleotide code: " + nuc);
+        }
+
+        return choices[rand.nextInt(choices.length)];
+    }
+
+    private char mutateCanonicalBase(char base) {
+        base = Character.toUpperCase(base);
+        int baseIdx = CANONICAL.indexOf(base);
+        if (baseIdx == -1) {
+            throw new IllegalArgumentException("Base must be one of A, C, G, T");
+        }
+        double[] probs = selectedMatrix[baseIdx];
+        // Build cumulative distribution
+        double r = rand.nextDouble();
+        double cumulative = 0.0;
+        for (int i = 0; i < probs.length; i++) {
+            if (i == baseIdx) continue; // skip self
+            cumulative += probs[i];
+            if (r < cumulative) {
+                return CANONICAL.get(i);
+            }
+        }
+        // Fallback (should not happen)
+        for (int i = 0; i < probs.length; i++) {
+            if (i != baseIdx && probs[i] > 0) {
+                return CANONICAL.get(i);
+            }
+        }
+        throw new IllegalStateException("No valid mutation found for base: " + base);
+    }
+
     private DNASequence mutate_seq(DNASequence seq) throws CompoundNotFoundException {
         StringBuilder mut_seq = new StringBuilder();
         for (int i=0; i<seq.getLength(); i++) {
-            Character nuc = seq.getCompoundAt(i+1).toString().charAt(0);
+            char nuc = Character.toUpperCase(seq.getCompoundAt(i+1).toString().charAt(0));
+
+            // Preserve gaps unchanged
+            if (nuc == '-') {
+                mut_seq.append(nuc);
+                continue;
+            }
+
+            // No mutation event: keep original symbol exactly as written
             if (Math.random() > nuc_mut_prob) {
                 mut_seq.append(nuc);
                 continue;
             }
-            Character mut_nuc = nucs.get(rand.nextInt(nucs.size()-1));
-            if (nuc == mut_nuc) nuc = nucs.get(3);
-            mut_seq.append(nuc);
+
+            // Mutation event: resolve ambiguity to one compatible base, then mutate away from that base
+            char resolved = resolveAmbiguousBase(nuc);
+            char mutated = mutateCanonicalBase(resolved);
+            mut_seq.append(mutated);
         }
         return new DNASequence(mut_seq.toString(), AmbiguityDNACompoundSet.getDNACompoundSet());
     }


### PR DESCRIPTION
- Add `--distribution/-d` CLI option for choosing between simple equal-probability mutations and an HIV-like mutation model.
- Replace random nucleotide substitution logic with matrix-driven base mutation.
- Resolve IUPAC ambiguous nucleotide codes before mutation while preserving gaps.